### PR TITLE
Failing test for HTTP username

### DIFF
--- a/test.js
+++ b/test.js
@@ -90,7 +90,7 @@ test('DocumentFragment support', t => {
 
 test('supports `@` in the URL path', t => {
 	t.is(m('https://sindresorhus.com/@foo'), '<a href="https://sindresorhus.com/@foo">https://sindresorhus.com/@foo</a>');
-	t.is(m('https://user@sindresorhus.com/@foo'), '<a href="https://user@sindresorhus.com/@foo">https://user@sindresorhus.com/@foo</a>');
+	t.fail(m('https://user@sindresorhus.com/@foo'), '<a href="https://user@sindresorhus.com/@foo">https://user@sindresorhus.com/@foo</a>');
 });
 
 test('skips email addresses', t => {

--- a/test.js
+++ b/test.js
@@ -90,7 +90,10 @@ test('DocumentFragment support', t => {
 
 test('supports `@` in the URL path', t => {
 	t.is(m('https://sindresorhus.com/@foo'), '<a href="https://sindresorhus.com/@foo">https://sindresorhus.com/@foo</a>');
-	t.fail(m('https://user@sindresorhus.com/@foo'), '<a href="https://user@sindresorhus.com/@foo">https://user@sindresorhus.com/@foo</a>');
+});
+
+test.failing('supports username in url', t => {
+    t.is(m('https://user@sindresorhus.com/@foo'), '<a href="https://user@sindresorhus.com/@foo">https://user@sindresorhus.com/@foo</a>');
 });
 
 test('skips email addresses', t => {

--- a/test.js
+++ b/test.js
@@ -90,6 +90,7 @@ test('DocumentFragment support', t => {
 
 test('supports `@` in the URL path', t => {
 	t.is(m('https://sindresorhus.com/@foo'), '<a href="https://sindresorhus.com/@foo">https://sindresorhus.com/@foo</a>');
+	t.is(m('https://user@sindresorhus.com/@foo'), '<a href="https://user@sindresorhus.com/@foo">https://user@sindresorhus.com/@foo</a>');
 });
 
 test('skips email addresses', t => {

--- a/test.js
+++ b/test.js
@@ -93,7 +93,7 @@ test('supports `@` in the URL path', t => {
 });
 
 test.failing('supports username in url', t => {
-    t.is(m('https://user@sindresorhus.com/@foo'), '<a href="https://user@sindresorhus.com/@foo">https://user@sindresorhus.com/@foo</a>');
+	t.is(m('https://user@sindresorhus.com/@foo'), '<a href="https://user@sindresorhus.com/@foo">https://user@sindresorhus.com/@foo</a>');
 });
 
 test('skips email addresses', t => {


### PR DESCRIPTION
Example (noticeable with Refined GitHub): https://github.com/scieloorg/opac_proc/blob/46d9f826d2519573b99418f11da1ce3f87bfa7eb/requirements.txt#L12-L14

Related: should it support `git+http` urls at all?