### PR TITLE
More functional regex for URL parsing

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,7 +5,7 @@
 const createHtmlElement = require('create-html-element');
 
 // Capture the whole URL in group 1 to keep string.split() support
-const urlRegex = () => (/((?:https?(?::\/\/))(?:www\.)?[a-zA-Z0-9-_.]+(?:\.[a-zA-Z0-9]{2,})(?:[-a-zA-Z0-9:%_+.~#?&//=@]*))/g);
+const urlRegex = () => (/((?:https?(?::\/\/))[^\s/$.?#].[^\s]*)/ig);
 
 // Get <a> element as string
 const linkify = (href, options) => createHtmlElement({

--- a/index.js
+++ b/index.js
@@ -5,7 +5,7 @@
 const createHtmlElement = require('create-html-element');
 
 // Capture the whole URL in group 1 to keep string.split() support
-const urlRegex = () => (/((?:https?(?::\/\/))[^\s/$.?#].[^\s]*)/ig);
+const urlRegex = () => (/((?:https?(?::\/\/))[^\s/$.?#].[^\s()]*)/ig);
 
 // Get <a> element as string
 const linkify = (href, options) => createHtmlElement({


### PR DESCRIPTION
This PR is more for a discussion about URL parsing than a direct PR.
Just found that a lot of URLs has been excluded with the actual regex, then I tried to find something better.

My proposal is based on Stephen Hay work as seen on https://mathiasbynens.be/demo/url-regex.
Still excluding parentheses, so links like `https://en.wikipedia.org/wiki/Kansas_(disambiguation)` are not well parsed.

🚀 