### PR TITLE
Support `,` in the URL path

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,7 +3,7 @@
 const createHtmlElement = require('create-html-element');
 
 // Capture the whole URL in group 1 to keep string.split() support
-const urlRegex = () => (/((?:https?(?::\/\/))(?:www\.)?[a-zA-Z0-9-_.]+(?:\.[a-zA-Z0-9]{2,})(?:[-a-zA-Z0-9:%_+.~#?&//=@]*))/g);
+const urlRegex = () => (/((?:https?(?::\/\/))(?:www\.)?[a-zA-Z0-9-_.]+(?:\.[a-zA-Z0-9]{2,})(?:[-a-zA-Z0-9:%_+.~#?&//=@,]*))/g);
 
 // Get <a> element as string
 const linkify = (href, options) => createHtmlElement({

--- a/index.js
+++ b/index.js
@@ -3,7 +3,7 @@
 const createHtmlElement = require('create-html-element');
 
 // Capture the whole URL in group 1 to keep string.split() support
-const urlRegex = () => (/((?:https?(?::\/\/))(?:www\.)?[a-zA-Z0-9-_.]+(?:\.[a-zA-Z0-9]{2,})(?:[-a-zA-Z0-9:%_+.~#?&//=@,]*))/g);
+const urlRegex = () => (/((?:https?(?::\/\/))(?:www\.)?[a-zA-Z0-9-_.]+(?:\.[a-zA-Z0-9]{2,})(?:(?:[-a-zA-Z0-9:%_+.~#?&//=@]*)(?:[,](?![\s]))*)*)/g);
 
 // Get <a> element as string
 const linkify = (href, options) => createHtmlElement({

--- a/test.js
+++ b/test.js
@@ -92,8 +92,9 @@ test('supports `@` in the URL path', t => {
 	t.is(m('https://sindresorhus.com/@foo'), '<a href="https://sindresorhus.com/@foo">https://sindresorhus.com/@foo</a>');
 });
 
-test('supports `,` in the URL path', t => {
+test('supports `,` in the URL path, but not at the end', t => {
 	t.is(m('https://sindresorhus.com/?id=foo,bar'), '<a href="https://sindresorhus.com/?id=foo,bar">https://sindresorhus.com/?id=foo,bar</a>');
+	t.is(m('https://sindresorhus.com/?id=foo, bar'), '<a href="https://sindresorhus.com/?id=foo">https://sindresorhus.com/?id=foo</a>, bar');
 });
 
 test('supports `value` option', t => {

--- a/test.js
+++ b/test.js
@@ -92,6 +92,10 @@ test('supports `@` in the URL path', t => {
 	t.is(m('https://sindresorhus.com/@foo'), '<a href="https://sindresorhus.com/@foo">https://sindresorhus.com/@foo</a>');
 });
 
+test('supports `,` in the URL path', t => {
+	t.is(m('https://sindresorhus.com/?id=foo,bar'), '<a href="https://sindresorhus.com/?id=foo,bar">https://sindresorhus.com/?id=foo,bar</a>');
+});
+
 test('supports `value` option', t => {
 	t.is(m('See https://github.com/sindresorhus.com/linkify-urls for a solution', {
 		type: 'string',


### PR DESCRIPTION
Currently if a urls with commas are truncated at the first comma
for example
```js
linkifyUrls('https://sindresorhus.com/?id=foo,bar')
// returns 
'<a href="https://sindresorhus.com/?id=foo">https://sindresorhus.com/?id=foo</a>,bar'
```
This PR adds a comma to the list of allowed path characters in the urlRegex. 
  