### PR TITLE
Escape the automatic URL value

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,7 +1,6 @@
 'use strict';
 // - const urlRegex = require('url-regex');
 const createHtmlElement = require('create-html-element');
-const {escape} = require('escape-goat');
 
 // Capture the whole URL in group 1 to keep string.split() support
 const urlRegex = () => (/((?:https?(?::\/\/))(?:www\.)?[a-zA-Z\d-_.]+(?:\.[a-zA-Z\d]{2,})(?:(?:[-a-zA-Z\d:%_+.~#!?&//=@]*)(?:[,](?![\s]))*)*)/g);
@@ -10,7 +9,8 @@ const urlRegex = () => (/((?:https?(?::\/\/))(?:www\.)?[a-zA-Z\d-_.]+(?:\.[a-zA-
 const linkify = (href, options) => createHtmlElement({
 	name: 'a',
 	attributes: Object.assign({href: ''}, options.attributes, {href}),
-	value: typeof options.value === 'undefined' ? escape(href) : options.value
+	text: typeof options.value === 'undefined' ? href : undefined,
+	html: typeof options.value === 'undefined' ? undefined : options.value
 });
 
 // Get DOM node from HTML

--- a/index.js
+++ b/index.js
@@ -1,6 +1,7 @@
 'use strict';
 // - const urlRegex = require('url-regex');
 const createHtmlElement = require('create-html-element');
+const {escape} = require('escape-goat');
 
 // Capture the whole URL in group 1 to keep string.split() support
 const urlRegex = () => (/((?:https?(?::\/\/))(?:www\.)?[a-zA-Z\d-_.]+(?:\.[a-zA-Z\d]{2,})(?:(?:[-a-zA-Z\d:%_+.~#!?&//=@]*)(?:[,](?![\s]))*)*)/g);
@@ -9,7 +10,7 @@ const urlRegex = () => (/((?:https?(?::\/\/))(?:www\.)?[a-zA-Z\d-_.]+(?:\.[a-zA-
 const linkify = (href, options) => createHtmlElement({
 	name: 'a',
 	attributes: Object.assign({href: ''}, options.attributes, {href}),
-	value: typeof options.value === 'undefined' ? href : options.value
+	value: typeof options.value === 'undefined' ? escape(href) : options.value
 });
 
 // Get DOM node from HTML

--- a/package.json
+++ b/package.json
@@ -29,8 +29,7 @@
 		"href"
 	],
 	"dependencies": {
-		"create-html-element": "^1.0.0",
-		"escape-goat": "^1.3.0",
+		"create-html-element": "^2.0.0",
 		"url-regex": "^4.0.0"
 	},
 	"devDependencies": {

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
 	],
 	"dependencies": {
 		"create-html-element": "^1.0.0",
+		"escape-goat": "^1.3.0",
 		"url-regex": "^4.0.0"
 	},
 	"devDependencies": {

--- a/test.js
+++ b/test.js
@@ -88,6 +88,10 @@ test('DocumentFragment support', t => {
 	);
 });
 
+test('escapes the URL', t => {
+	t.is(m('http://mysite.com/?emp=1&amp=2'), '<a href="http://mysite.com/?emp=1&amp;amp=2">http://mysite.com/?emp=1&amp;amp=2</a>');
+});
+
 test('supports `@` in the URL path', t => {
 	t.is(m('https://sindresorhus.com/@foo'), '<a href="https://sindresorhus.com/@foo">https://sindresorhus.com/@foo</a>');
 });


### PR DESCRIPTION
Fixes #14 
Fixes sindresorhus/refined-github#811

It does not escape the `value` because the user might not want that and we don't want an option for that. So they should use `escape-goat` explicitly in that case.