### PR TITLE
Explicitly allow localhost URLs

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,7 +3,7 @@
 const createHtmlElement = require('create-html-element');
 
 // Capture the whole URL in group 1 to keep string.split() support
-const urlRegex = () => (/((?:https?(?::\/\/))(?:www\.)?[a-zA-Z\d-_.]+(?:\.[a-zA-Z\d]{2,})(?:(?:[-a-zA-Z\d:%_+.~#!?&//=@]*)(?:[,](?![\s]))*)*)/g);
+const urlRegex = () => (/((?:https?(?::\/\/))(?:www\.)?(?:[a-zA-Z\d-_.]+(?:\.[a-zA-Z\d]{2,})|localhost)(?:(?:[-a-zA-Z\d:%_+.~#!?&//=@]*)(?:[,](?![\s]))*)*)/g);
 
 // Get <a> element as string
 const linkify = (href, options) => createHtmlElement({

--- a/test.js
+++ b/test.js
@@ -113,7 +113,7 @@ test('supports `value` option', t => {
 });
 
 test.failing('skips Git URLs', t => {
-	const fixture = 'git+https://github.com/sindreorhus/ava';
+	const fixture = 'git+https://github.com/sindresorhus/ava';
 	t.is(m(fixture), fixture);
 });
 
@@ -125,4 +125,9 @@ test('skips email addresses', t => {
 	t.is(m('sindre@example.com'), 'sindre@example.com');
 	t.is(m('www.sindre@example.com'), 'www.sindre@example.com');
 	t.is(m('sindre@www.example.com'), 'sindre@www.example.com');
+});
+
+test('supports localhost URLs', t => {
+	t.is(m('http://localhost'), '<a href="http://localhost">http://localhost</a>');
+	t.is(m('http://localhost/foo/bar'), '<a href="http://localhost/foo/bar">http://localhost/foo/bar</a>');
 });


### PR DESCRIPTION
Fixes #19 by matching domains without TLD (`.com`, `.net`, etc.) as long as they are exactly `localhost`.