### PR TITLE
Correctly skip plus-prefixed URLs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,4 +2,3 @@ language: node_js
 node_js:
   - '10'
   - '8'
-  - '6'

--- a/index.js
+++ b/index.js
@@ -2,7 +2,7 @@
 const createHtmlElement = require('create-html-element');
 
 // Capture the whole URL in group 1 to keep string.split() support
-const urlRegex = () => (/((?:https?(?::\/\/))(?:www\.)?(?:[a-zA-Z\d-_.]+(?:(?:\.|@)[a-zA-Z\d]{2,})|localhost)(?:(?:[-a-zA-Z\d:%_+.~#!?&//=@]*)(?:[,](?![\s]))*)*)/g);
+const urlRegex = () => (/((?<!\+)(?:https?(?::\/\/))(?:www\.)?(?:[a-zA-Z\d-_.]+(?:\.|@[a-zA-Z\d]{2,})|localhost)(?:(?:[-a-zA-Z\d:%_+.~#!?&//=@]*)(?:[,](?![\s]))*)*)/g);
 
 // Get <a> element as string
 const linkify = (href, options) => createHtmlElement({

--- a/index.js
+++ b/index.js
@@ -2,7 +2,7 @@
 const createHtmlElement = require('create-html-element');
 
 // Capture the whole URL in group 1 to keep string.split() support
-const urlRegex = () => (/((?<!\+)(?:https?(?::\/\/))(?:www\.)?(?:[a-zA-Z\d-_.]+(?:\.|@[a-zA-Z\d]{2,})|localhost)(?:(?:[-a-zA-Z\d:%_+.~#!?&//=@]*)(?:[,](?![\s]))*)*)/g);
+const urlRegex = () => (/((?<!\+)(?:https?(?::\/\/))(?:www\.)?(?:[a-zA-Z\d-_.]+(?:(?:\.|@)[a-zA-Z\d]{2,})|localhost)(?:(?:[-a-zA-Z\d:%_+.~#!?&//=@]*)(?:[,](?![\s]))*)*)/g);
 
 // Get <a> element as string
 const linkify = (href, options) => createHtmlElement({

--- a/readme.md
+++ b/readme.md
@@ -85,6 +85,12 @@ linkifyUrls('See https://sindresorhus.com/foo', {
 //=> 'See <a href="https://sindresorhus.com/foo">/foo</a>'
 ```
 
+## Compatibility note
+
+Since v2.2.0, the main regular expression is using a negative look-behind to address [#7](https://github.com/sindresorhus/linkify-urls/issues/7).
+Look-behind assertions [should be compatible since Node v6](https://node.green/#ES2018-features--RegExp-Lookbehind-Assertions) (with the use of `--harmony` flag).
+At the time of this note, only Google Chrome seems to support it, even though it [will eventually be a standard](https://tc39.github.io/ecma262/).
+
 
 ## Related
 

--- a/test.js
+++ b/test.js
@@ -119,7 +119,7 @@ test('supports `value` option as function', t => {
 	}), 'See <a href="https://github.com/sindresorhus.com/linkify-urls">github.com</a> for a solution');
 });
 
-test('skips Git URLs', t => {
+test('skips URLs preceded by a `+` sign', t => {
 	const fixture = 'git+https://github.com/sindresorhus/ava';
 	t.is(m(fixture), fixture);
 });

--- a/test.js
+++ b/test.js
@@ -119,7 +119,7 @@ test('supports `value` option as function', t => {
 	}), 'See <a href="https://github.com/sindresorhus.com/linkify-urls">github.com</a> for a solution');
 });
 
-test.failing('skips Git URLs', t => {
+test('skips Git URLs', t => {
 	const fixture = 'git+https://github.com/sindresorhus/ava';
 	t.is(m(fixture), fixture);
 });


### PR DESCRIPTION
Should fix #7 

How: Adding a negative lookbehind on the main RegEx to ignore URLs preceded by
Why: Negative lookbehinds seem to be supported since Node v6 with the `--harmony` flag (ref: https://node.green/#ES2018-features--RegExp-Lookbehind-Assertions) and should also be supported in ES2019 (ref: https://tc39.github.io/ecma262/).

Please note that it doesn't specifically ignore URLs that start with `git+`, just the `+` is being taken into account.

So I would suggest 1 of 2 changes:
If it makes sense to apply this same rule for any other URLs that might follow the same schema but not exactly git-specific I would suggest **(a)** tweak the `skips Git URLs` test name itself. Otherwise, **(b)** the RegEx should be tweaked to explicitly ignore `git+` URLs.

Let me know what you think.