### PR TITLE
Add support for username in URL

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,7 +2,7 @@
 const createHtmlElement = require('create-html-element');
 
 // Capture the whole URL in group 1 to keep string.split() support
-const urlRegex = () => (/((?:https?(?::\/\/))(?:www\.)?(?:[a-zA-Z\d-_.]+(?:\.[a-zA-Z\d]{2,})|localhost)(?:(?:[-a-zA-Z\d:%_+.~#!?&//=@]*)(?:[,](?![\s]))*)*)/g);
+const urlRegex = () => (/((?:https?(?::\/\/))(?:www\.)?(?:[a-zA-Z\d-_.]+(?:(?:\.|@)[a-zA-Z\d]{2,})|localhost)(?:(?:[-a-zA-Z\d:%_+.~#!?&//=@]*)(?:[,](?![\s]))*)*)/g);
 
 // Get <a> element as string
 const linkify = (href, options) => createHtmlElement({

--- a/test.js
+++ b/test.js
@@ -124,8 +124,12 @@ test.failing('skips Git URLs', t => {
 	t.is(m(fixture), fixture);
 });
 
-test.failing('supports username in url', t => {
+test('supports username in url', t => {
 	t.is(m('https://user@sindresorhus.com/@foo'), '<a href="https://user@sindresorhus.com/@foo">https://user@sindresorhus.com/@foo</a>');
+});
+
+test('supports a URL with a subdomain', t => {
+	t.is(m('http://docs.google.com'), '<a href="http://docs.google.com">http://docs.google.com</a>');
 });
 
 test('skips email addresses', t => {


### PR DESCRIPTION
Should fix the `supports username in url` failing test and also include one more test for a subdomain URL like `http://docs.google.com`, which was already supported but not tested.

How: By expecting either a `.` or `@` after the first group of strings in the main RegEx.