### PR TITLE
Publish version to support engines without lookbehind support

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,7 +2,14 @@
 const createHtmlElement = require('create-html-element');
 
 // Capture the whole URL in group 1 to keep `String#split()` support
-const urlRegex = () => (/((?<!\+)(?:https?(?::\/\/))(?:www\.)?(?:[a-zA-Z\d-_.]+(?:(?:\.|@)[a-zA-Z\d]{2,})|localhost)(?:(?:[-a-zA-Z\d:%_+.~#!?&//=@]*)(?:[,](?![\s]))*)*)/g);
+const urlRegex = () => {
+	try {
+		return new RegExp('((?<!\\+)(?:https?(?::\\/\\/))(?:www\\.)?(?:[a-zA-Z\\d-_.]+(?:(?:\\.|@)[a-zA-Z\\d]{2,})|localhost)(?:(?:[-a-zA-Z\\d:%_+.~#!?&\\/\\/=@]*)(?:[,](?![\\s]))*)*)', 'g');
+	} catch {
+		// No lookbehind support: https://bugzilla.mozilla.org/show_bug.cgi?id=1225665
+		return new RegExp('((?:https?(?::\\/\\/))(?:www\\.)?(?:[a-zA-Z\\d-_.]+(?:(?:\\.|@)[a-zA-Z\\d]{2,})|localhost)(?:(?:[-a-zA-Z\\d:%_+.~#!?&//=@]*)(?:[,](?![\\s]))*)*)', 'g');
+	}
+};
 
 // Get `<a>` element as string
 const linkify = (href, options) => createHtmlElement({

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "linkify-urls",
-	"version": "3.1.0",
+	"version": "3.1.0-nolookbehind",
 	"description": "Linkify URLs in a string",
 	"license": "MIT",
 	"repository": "sindresorhus/linkify-urls",


### PR DESCRIPTION
This has been published under the tag `nolookbehind` as a one-off upgrade path for v2 users. It's not meant to be merged into `master`.

Install it with 

```sh
npm i linkify-urls@nolookbehind
```