### PR TITLE
Add `rel="noreferrer"` as default attribute

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -12,7 +12,7 @@ declare namespace linkifyUrls {
 		/**
 		Format of the generated content.
 
-		`'string'` will return it as a flat string like `'Visit <a href="https://example.com">https://example.com</a>'`.
+		`'string'` will return it as a flat string like `'Visit <a href="https://example.com" rel="noreferrer">https://example.com</a>'`.
 
 		`'dom'` will return it as a `DocumentFragment` ready to be appended in a DOM safely, like `DocumentFragment(TextNode('Visit '), HTMLAnchorElement('https://example.com'))`. This type only works in the browser.
 		*/
@@ -28,7 +28,7 @@ declare namespace linkifyUrls {
 		linkifyUrls('See https://sindresorhus.com/foo', {
 			value: url => new URL(url).pathname
 		});
-		//=> 'See <a href="https://sindresorhus.com/foo">/foo</a>'
+		//=> 'See <a href="https://sindresorhus.com/foo" rel="noreferrer">/foo</a>'
 		```
 		*/
 		readonly value?: string | ((url: string) => string);
@@ -57,7 +57,7 @@ linkifyUrls('See https://sindresorhus.com', {
 		multiple: ['a', 'b']
 	}
 });
-//=> 'See <a href="https://sindresorhus.com" class="unicorn" one="1" foo multiple="a b">https://sindresorhus.com</a>'
+//=> 'See <a href="https://sindresorhus.com" rel="noreferrer" class="unicorn" one="1" foo multiple="a b">https://sindresorhus.com</a>'
 
 
 // In the browser

--- a/index.js
+++ b/index.js
@@ -36,11 +36,21 @@ const getAsDocumentFragment = (string, options) => {
 	}, document.createDocumentFragment());
 };
 
-module.exports = (string, options) => {
+module.exports = (string, options = {}) => {
+	const defaultOptions = {
+		attributes: {
+			rel: 'noreferrer'
+		},
+		type: 'string'
+	};
+
 	options = {
-		attributes: {},
-		type: 'string',
-		...options
+		...defaultOptions,
+		...options,
+		attributes: {
+			...defaultOptions.attributes,
+			...options.attributes
+		}
 	};
 
 	if (options.type === 'string') {

--- a/readme.md
+++ b/readme.md
@@ -23,7 +23,7 @@ linkifyUrls('See https://sindresorhus.com', {
 		multiple: ['a', 'b']
 	}
 });
-//=> 'See <a href="https://sindresorhus.com" class="unicorn" one="1" foo multiple="a b">https://sindresorhus.com</a>'
+//=> 'See <a href="https://sindresorhus.com" rel="noreferrer" class="unicorn" one="1" foo multiple="a b">https://sindresorhus.com</a>'
 
 
 // In the browser
@@ -56,6 +56,7 @@ Type: `object`
 Type: `object`
 
 HTML attributes to add to the link.
+By default there is the `rel="noreferrer"` based on [Google Lighthouse Audits](https://developers.google.com/web/tools/lighthouse/audits/noopener) this should be the default for cross-origin destinations.
 
 ##### type
 

--- a/test.js
+++ b/test.js
@@ -30,7 +30,7 @@ const html = dom => {
 test('main', t => {
 	t.is(
 		linkifyUrls('See https://sindresorhus.com and https://github.com/sindresorhus/got'),
-		'See <a href="https://sindresorhus.com">https://sindresorhus.com</a> and <a href="https://github.com/sindresorhus/got">https://github.com/sindresorhus/got</a>'
+		'See <a href="https://sindresorhus.com" rel="noreferrer">https://sindresorhus.com</a> and <a href="https://github.com/sindresorhus/got" rel="noreferrer">https://github.com/sindresorhus/got</a>'
 	);
 
 	t.is(
@@ -40,12 +40,12 @@ test('main', t => {
 				target: '_blank'
 			}
 		}),
-		'See <a href="https://sindresorhus.com" class="unicorn" target="_blank">https://sindresorhus.com</a>'
+		'See <a href="https://sindresorhus.com" rel="noreferrer" class="unicorn" target="_blank">https://sindresorhus.com</a>'
 	);
 
 	t.is(
 		linkifyUrls('[![Build Status](https://travis-ci.org/sindresorhus/caprine.svg?branch=master)](https://travis-ci.org/sindresorhus/caprine)'),
-		'[![Build Status](<a href="https://travis-ci.org/sindresorhus/caprine.svg?branch=master">https://travis-ci.org/sindresorhus/caprine.svg?branch=master</a>)](<a href="https://travis-ci.org/sindresorhus/caprine">https://travis-ci.org/sindresorhus/caprine</a>)'
+		'[![Build Status](<a href="https://travis-ci.org/sindresorhus/caprine.svg?branch=master" rel="noreferrer">https://travis-ci.org/sindresorhus/caprine.svg?branch=master</a>)](<a href="https://travis-ci.org/sindresorhus/caprine" rel="noreferrer">https://travis-ci.org/sindresorhus/caprine</a>)'
 	);
 });
 
@@ -58,7 +58,7 @@ test('supports boolean and non-string attribute values', t => {
 				one: 1
 			}
 		}),
-		'<a href="https://sindresorhus.com" foo one="1">https://sindresorhus.com</a>'
+		'<a href="https://sindresorhus.com" rel="noreferrer" foo one="1">https://sindresorhus.com</a>'
 	);
 });
 
@@ -67,7 +67,7 @@ test('DocumentFragment support', t => {
 		html(linkifyUrls('See https://sindresorhus.com and https://github.com/sindresorhus/got', {
 			type: 'dom'
 		})),
-		html(domify('See <a href="https://sindresorhus.com">https://sindresorhus.com</a> and <a href="https://github.com/sindresorhus/got">https://github.com/sindresorhus/got</a>'))
+		html(domify('See <a href="https://sindresorhus.com" rel="noreferrer">https://sindresorhus.com</a> and <a href="https://github.com/sindresorhus/got" rel="noreferrer">https://github.com/sindresorhus/got</a>'))
 	);
 
 	t.is(
@@ -78,45 +78,45 @@ test('DocumentFragment support', t => {
 				target: '_blank'
 			}
 		})),
-		html(domify('See <a href="https://sindresorhus.com" class="unicorn" target="_blank">https://sindresorhus.com</a>'))
+		html(domify('See <a href="https://sindresorhus.com" rel="noreferrer" class="unicorn" target="_blank">https://sindresorhus.com</a>'))
 	);
 
 	t.is(
 		html(linkifyUrls('[![Build Status](https://travis-ci.org/sindresorhus/caprine.svg?branch=master)](https://travis-ci.org/sindresorhus/caprine)', {
 			type: 'dom'
 		})),
-		html(domify('[![Build Status](<a href="https://travis-ci.org/sindresorhus/caprine.svg?branch=master">https://travis-ci.org/sindresorhus/caprine.svg?branch=master</a>)](<a href="https://travis-ci.org/sindresorhus/caprine">https://travis-ci.org/sindresorhus/caprine</a>)'))
+		html(domify('[![Build Status](<a href="https://travis-ci.org/sindresorhus/caprine.svg?branch=master" rel="noreferrer">https://travis-ci.org/sindresorhus/caprine.svg?branch=master</a>)](<a href="https://travis-ci.org/sindresorhus/caprine" rel="noreferrer">https://travis-ci.org/sindresorhus/caprine</a>)'))
 	);
 });
 
 test('escapes the URL', t => {
-	t.is(linkifyUrls('http://mysite.com/?emp=1&amp=2'), '<a href="http://mysite.com/?emp=1&amp;amp=2">http://mysite.com/?emp=1&amp;amp=2</a>');
+	t.is(linkifyUrls('http://mysite.com/?emp=1&amp=2'), '<a href="http://mysite.com/?emp=1&amp;amp=2" rel="noreferrer">http://mysite.com/?emp=1&amp;amp=2</a>');
 });
 
 test('supports `@` in the URL path', t => {
-	t.is(linkifyUrls('https://sindresorhus.com/@foo'), '<a href="https://sindresorhus.com/@foo">https://sindresorhus.com/@foo</a>');
+	t.is(linkifyUrls('https://sindresorhus.com/@foo'), '<a href="https://sindresorhus.com/@foo" rel="noreferrer">https://sindresorhus.com/@foo</a>');
 });
 
 test('supports `#!` in the URL path', t => {
-	t.is(linkifyUrls('https://twitter.com/#!/sindresorhus'), '<a href="https://twitter.com/#!/sindresorhus">https://twitter.com/#!/sindresorhus</a>');
+	t.is(linkifyUrls('https://twitter.com/#!/sindresorhus'), '<a href="https://twitter.com/#!/sindresorhus" rel="noreferrer">https://twitter.com/#!/sindresorhus</a>');
 });
 
 test('supports `,` in the URL path, but not at the end', t => {
-	t.is(linkifyUrls('https://sindresorhus.com/?id=foo,bar'), '<a href="https://sindresorhus.com/?id=foo,bar">https://sindresorhus.com/?id=foo,bar</a>');
-	t.is(linkifyUrls('https://sindresorhus.com/?id=foo, bar'), '<a href="https://sindresorhus.com/?id=foo">https://sindresorhus.com/?id=foo</a>, bar');
+	t.is(linkifyUrls('https://sindresorhus.com/?id=foo,bar'), '<a href="https://sindresorhus.com/?id=foo,bar" rel="noreferrer">https://sindresorhus.com/?id=foo,bar</a>');
+	t.is(linkifyUrls('https://sindresorhus.com/?id=foo, bar'), '<a href="https://sindresorhus.com/?id=foo" rel="noreferrer">https://sindresorhus.com/?id=foo</a>, bar');
 });
 
 test('supports `value` option', t => {
 	t.is(linkifyUrls('See https://github.com/sindresorhus.com/linkify-urls for a solution', {
 		type: 'string',
 		value: 0
-	}), 'See <a href="https://github.com/sindresorhus.com/linkify-urls">0</a> for a solution');
+	}), 'See <a href="https://github.com/sindresorhus.com/linkify-urls" rel="noreferrer">0</a> for a solution');
 });
 
 test('supports `value` option as function', t => {
 	t.is(linkifyUrls('See https://github.com/sindresorhus.com/linkify-urls for a solution', {
 		value: url => new URL(url).hostname
-	}), 'See <a href="https://github.com/sindresorhus.com/linkify-urls">github.com</a> for a solution');
+	}), 'See <a href="https://github.com/sindresorhus.com/linkify-urls" rel="noreferrer">github.com</a> for a solution');
 });
 
 test('skips URLs preceded by a `+` sign', t => {
@@ -125,11 +125,11 @@ test('skips URLs preceded by a `+` sign', t => {
 });
 
 test('supports username in url', t => {
-	t.is(linkifyUrls('https://user@sindresorhus.com/@foo'), '<a href="https://user@sindresorhus.com/@foo">https://user@sindresorhus.com/@foo</a>');
+	t.is(linkifyUrls('https://user@sindresorhus.com/@foo'), '<a href="https://user@sindresorhus.com/@foo" rel="noreferrer">https://user@sindresorhus.com/@foo</a>');
 });
 
 test('supports a URL with a subdomain', t => {
-	t.is(linkifyUrls('http://docs.google.com'), '<a href="http://docs.google.com">http://docs.google.com</a>');
+	t.is(linkifyUrls('http://docs.google.com'), '<a href="http://docs.google.com" rel="noreferrer">http://docs.google.com</a>');
 });
 
 test('skips email addresses', t => {
@@ -139,6 +139,22 @@ test('skips email addresses', t => {
 });
 
 test('supports localhost URLs', t => {
-	t.is(linkifyUrls('http://localhost'), '<a href="http://localhost">http://localhost</a>');
-	t.is(linkifyUrls('http://localhost/foo/bar'), '<a href="http://localhost/foo/bar">http://localhost/foo/bar</a>');
+	t.is(linkifyUrls('http://localhost'), '<a href="http://localhost" rel="noreferrer">http://localhost</a>');
+	t.is(linkifyUrls('http://localhost/foo/bar'), '<a href="http://localhost/foo/bar" rel="noreferrer">http://localhost/foo/bar</a>');
+});
+
+test('skips rel="noreferrer"', t => {
+	t.is(linkifyUrls('http://localhost', {
+		attributes: {
+			rel: false
+		}
+	}), '<a href="http://localhost">http://localhost</a>');
+});
+
+test('overwrites rel to "nofollow"', t => {
+	t.is(linkifyUrls('http://localhost', {
+		attributes: {
+			rel: 'nofollow'
+		}
+	}), '<a href="http://localhost" rel="nofollow">http://localhost</a>');
 });


### PR DESCRIPTION
Based on https://developers.google.com/web/tools/lighthouse/audits/noopener this should be the default for cross-origin destinations