### PR TITLE
Skip truncated links

### DIFF
--- a/index.js
+++ b/index.js
@@ -19,7 +19,7 @@ const linkify = (href, options) => createHtmlElement({
 // Get DOM node from HTML
 const domify = html => document.createRange().createContextualFragment(html);
 
-const getAsString = (string, options) => string.replace(urlRegex(), (match, _, offset) => offset + match.length + 1 === string.length && string.charAt(offset + match.length) === '…' ? match : linkify(match, options));
+const getAsString = (string, options) => string.replace(urlRegex(), (match, _, offset) => offset + match.length + 1 === string.length && string.charAt(string.length - 1) === '…' ? match : linkify(match, options));
 
 const getAsDocumentFragment = (string, options) => {
 	const fragment = document.createDocumentFragment();

--- a/index.js
+++ b/index.js
@@ -19,9 +19,9 @@ const linkify = (href, options) => createHtmlElement({
 // Get DOM node from HTML
 const domify = html => document.createRange().createContextualFragment(html);
 
-const isTruncated = (index, entries) => index + 2 === entries.length && entries[entries.length - 1][1] === '…';
+const isTruncated = (index, entries) => index + 2 === entries.length && (entries[entries.length - 1][1] === '…' || (entries[index][1].endsWith('...') && entries[entries.length - 1][1] === ''));
 
-const getAsString = (string, options) => string.replace(urlRegex(), (match, _, offset) => offset + match.length + 1 === string.length && string.endsWith('…') ? match : linkify(match, options));
+const getAsString = (string, options) => string.replace(urlRegex(), (match, _, offset) => (offset + match.length + 1 === string.length && string.endsWith('…')) || (offset + match.length === string.length && string.endsWith('...')) ? match : linkify(match, options));
 
 const getAsDocumentFragment = (string, options) => {
 	const fragment = document.createDocumentFragment();

--- a/index.js
+++ b/index.js
@@ -19,7 +19,7 @@ const linkify = (href, options) => createHtmlElement({
 // Get DOM node from HTML
 const domify = html => document.createRange().createContextualFragment(html);
 
-const getAsString = (string, options) => string.replace(urlRegex(), (match, _, offset) => offset + match.length + 1 === string.length && string.charAt(string.length - 1) === '…' ? match : linkify(match, options));
+const getAsString = (string, options) => string.replace(urlRegex(), (match, _, offset) => offset + match.length + 1 === string.length && string.endsWith('…') ? match : linkify(match, options));
 
 const getAsDocumentFragment = (string, options) => {
 	const fragment = document.createDocumentFragment();

--- a/index.js
+++ b/index.js
@@ -25,7 +25,7 @@ const getAsDocumentFragment = (string, options) => {
 	const fragment = document.createDocumentFragment();
 	const entries = Object.entries(string.split(urlRegex())).map(([k, v]) => [Number(k), v]);
 	for (const [index, text] of entries) {
-		if (index % 2 && (index + 2 < entries.length || entries[index + 1][1] !== '…')) { // URLs are always in odd positions
+		if (index % 2 && (index + 2 < entries.length || entries[entries.length - 1][1] !== '…')) { // URLs are always in odd positions
 			fragment.append(domify(linkify(text, options)));
 		} else if (text.length > 0) {
 			fragment.append(text);

--- a/index.js
+++ b/index.js
@@ -32,7 +32,7 @@ const getAsDocumentFragment = (string, options) => {
 	const fragment = document.createDocumentFragment();
 	const parts = string.split(urlRegex());
 
-	for (const [index, text] of parts) {
+	for (const [index, text] of parts.entries()) {
 		// URLs are always in odd positions
 		if (index % 2 && !isTruncated(text, parts[index + 1])) {
 			fragment.append(domify(linkify(text, options)));

--- a/index.js
+++ b/index.js
@@ -19,13 +19,13 @@ const linkify = (href, options) => createHtmlElement({
 // Get DOM node from HTML
 const domify = html => document.createRange().createContextualFragment(html);
 
-const getAsString = (string, options) => string.replace(urlRegex(), (match, _, offset) => string.charAt(offset + match.length) === '…' ? match : linkify(match, options));
+const getAsString = (string, options) => string.replace(urlRegex(), (match, _, offset) => offset + match.length + 1 === string.length && string.charAt(offset + match.length) === '…' ? match : linkify(match, options));
 
 const getAsDocumentFragment = (string, options) => {
 	const fragment = document.createDocumentFragment();
 	const entries = Object.entries(string.split(urlRegex())).map(([k, v]) => [Number(k), v]);
 	for (const [index, text] of entries) {
-		if (index % 2 && (index - 1 === entries.length || (index + 1 < entries.length && entries[index + 1][1].charAt(0) !== '…'))) { // URLs are always in odd positions
+		if (index % 2 && (index + 2 < entries.length || entries[index + 1][1] !== '…')) { // URLs are always in odd positions
 			fragment.append(domify(linkify(text, options)));
 		} else if (text.length > 0) {
 			fragment.append(text);

--- a/index.js
+++ b/index.js
@@ -19,13 +19,15 @@ const linkify = (href, options) => createHtmlElement({
 // Get DOM node from HTML
 const domify = html => document.createRange().createContextualFragment(html);
 
+const isTruncated = (index, entries) => index + 2 === entries.length && entries[entries.length - 1][1] === '…';
+
 const getAsString = (string, options) => string.replace(urlRegex(), (match, _, offset) => offset + match.length + 1 === string.length && string.endsWith('…') ? match : linkify(match, options));
 
 const getAsDocumentFragment = (string, options) => {
 	const fragment = document.createDocumentFragment();
 	const entries = [...string.split(urlRegex()).entries()];
 	for (const [index, text] of entries) {
-		if (index % 2 && (index + 2 < entries.length || entries[entries.length - 1][1] !== '…')) { // URLs are always in odd positions
+		if (index % 2 && !isTruncated(index, entries)) { // URLs are always in odd positions
 			fragment.append(domify(linkify(text, options)));
 		} else if (text.length > 0) {
 			fragment.append(text);

--- a/index.js
+++ b/index.js
@@ -19,9 +19,13 @@ const linkify = (href, options) => createHtmlElement({
 // Get DOM node from HTML
 const domify = html => document.createRange().createContextualFragment(html);
 
-const isTruncated = (index, entries) => index + 2 === entries.length && (entries[entries.length - 1][1] === '…' || (entries[index][1].endsWith('...') && entries[entries.length - 1][1] === ''));
+// If URL followed by … or ends with ...
+const isTruncated = (index, entries) => entries[index + 1][1].startsWith('…') || entries[index][1].endsWith('...');
 
-const getAsString = (string, options) => string.replace(urlRegex(), (match, _, offset) => (offset + match.length + 1 === string.length && string.endsWith('…')) || (offset + match.length === string.length && string.endsWith('...')) ? match : linkify(match, options));
+// If URL followed by … or ends with ...
+const getAsString = (string, options) => string.replace(urlRegex(), (match, _, offset) =>
+	string.charAt(offset + match.length) === '…'
+	|| match.endsWith('...') ? match : linkify(match, options));
 
 const getAsDocumentFragment = (string, options) => {
 	const fragment = document.createDocumentFragment();

--- a/index.js
+++ b/index.js
@@ -19,12 +19,13 @@ const linkify = (href, options) => createHtmlElement({
 // Get DOM node from HTML
 const domify = html => document.createRange().createContextualFragment(html);
 
-const getAsString = (string, options) => string.replace(urlRegex(), match => linkify(match, options));
+const getAsString = (string, options) => string.replace(urlRegex(), (match, _, offset) => string.charAt(offset + match.length) === '…' ? match : linkify(match, options));
 
 const getAsDocumentFragment = (string, options) => {
 	const fragment = document.createDocumentFragment();
-	for (const [index, text] of Object.entries(string.split(urlRegex()))) {
-		if (index % 2) { // URLs are always in odd positions
+	const entries = Object.entries(string.split(urlRegex())).map(([k, v]) => [Number(k), v]);
+	for (const [index, text] of entries) {
+		if (index % 2 && (index - 1 === entries.length || (index + 1 < entries.length && entries[index + 1][1].charAt(0) !== '…'))) { // URLs are always in odd positions
 			fragment.append(domify(linkify(text, options)));
 		} else if (text.length > 0) {
 			fragment.append(text);

--- a/index.js
+++ b/index.js
@@ -25,7 +25,7 @@ const isTruncated = (url, peek) =>
 
 const getAsString = (string, options) => string.replace(urlRegex(), (url, _, offset) =>
 	(isTruncated(url, string.charAt(offset + url.length)))
-		? url
+		? url // Don't linkify truncated URLs
 		: linkify(url, options));
 
 const getAsDocumentFragment = (string, options) => {

--- a/index.js
+++ b/index.js
@@ -23,7 +23,7 @@ const getAsString = (string, options) => string.replace(urlRegex(), (match, _, o
 
 const getAsDocumentFragment = (string, options) => {
 	const fragment = document.createDocumentFragment();
-	const entries = Object.entries(string.split(urlRegex())).map(([k, v]) => [Number(k), v]);
+	const entries = [...string.split(urlRegex()).entries()];
 	for (const [index, text] of entries) {
 		if (index % 2 && (index + 2 < entries.length || entries[entries.length - 1][1] !== '…')) { // URLs are always in odd positions
 			fragment.append(domify(linkify(text, options)));

--- a/index.js
+++ b/index.js
@@ -19,21 +19,22 @@ const linkify = (href, options) => createHtmlElement({
 // Get DOM node from HTML
 const domify = html => document.createRange().createContextualFragment(html);
 
-// If URL followed by `…` or ends with `...`.
-const isTruncated = (index, entries) => entries[index + 1][1].startsWith('…') || entries[index][1].endsWith('...');
+const isTruncated = (url, peek) =>
+	url.endsWith('...') // `...` is a matched by the URL regex
+	|| peek.startsWith('…'); // `…` can follow the match
 
-// If URL followed by `…` or ends with `...`.
-const getAsString = (string, options) => string.replace(urlRegex(), (match, _, offset) =>
-	(string.charAt(offset + match.length) === '…' || match.endsWith('...'))
-		? match
-		: linkify(match, options));
+const getAsString = (string, options) => string.replace(urlRegex(), (url, _, offset) =>
+	(isTruncated(url, string.charAt(offset + url.length)))
+		? url
+		: linkify(url, options));
 
 const getAsDocumentFragment = (string, options) => {
 	const fragment = document.createDocumentFragment();
-	const entries = [...string.split(urlRegex()).entries()];
+	const parts = string.split(urlRegex());
 
-	for (const [index, text] of entries) {
-		if (index % 2 && !isTruncated(index, entries)) { // URLs are always in odd positions
+	for (const [index, text] of parts) {
+		// URLs are always in odd positions
+		if (index % 2 && !isTruncated(text, parts[index + 1])) {
 			fragment.append(domify(linkify(text, options)));
 		} else if (text.length > 0) {
 			fragment.append(text);

--- a/index.js
+++ b/index.js
@@ -19,17 +19,19 @@ const linkify = (href, options) => createHtmlElement({
 // Get DOM node from HTML
 const domify = html => document.createRange().createContextualFragment(html);
 
-// If URL followed by … or ends with ...
+// If URL followed by `…` or ends with `...`.
 const isTruncated = (index, entries) => entries[index + 1][1].startsWith('…') || entries[index][1].endsWith('...');
 
-// If URL followed by … or ends with ...
+// If URL followed by `…` or ends with `...`.
 const getAsString = (string, options) => string.replace(urlRegex(), (match, _, offset) =>
-	string.charAt(offset + match.length) === '…'
-	|| match.endsWith('...') ? match : linkify(match, options));
+	(string.charAt(offset + match.length) === '…' || match.endsWith('...'))
+		? match
+		: linkify(match, options));
 
 const getAsDocumentFragment = (string, options) => {
 	const fragment = document.createDocumentFragment();
 	const entries = [...string.split(urlRegex()).entries()];
+
 	for (const [index, text] of entries) {
 		if (index % 2 && !isTruncated(index, entries)) { // URLs are always in odd positions
 			fragment.append(domify(linkify(text, options)));

--- a/test.js
+++ b/test.js
@@ -147,3 +147,13 @@ test('supports localhost URLs', t => {
 	t.is(linkifyUrls('https://localhost'), '<a href="https://localhost">https://localhost</a>');
 	t.is(linkifyUrls('https://localhost/foo/bar'), '<a href="https://localhost/foo/bar">https://localhost/foo/bar</a>');
 });
+
+test('skips truncated URLs', t => {
+	t.is(linkifyUrls('https://github.com/sindresorhus.com/linkify-…'), 'https://github.com/sindresorhus.com/linkify-…');
+	t.is(
+		html(linkifyUrls('See https://github.com/sindresorhus.com/linkify-urls and https://github.com/sindresorhus.com/linkify-…', {
+			type: 'dom',
+		})),
+		html(domify('See <a href="https://github.com/sindresorhus.com/linkify-urls">https://github.com/sindresorhus.com/linkify-urls</a> and https://github.com/sindresorhus.com/linkify-…')),
+	);
+});

--- a/test.js
+++ b/test.js
@@ -149,18 +149,18 @@ test('supports localhost URLs', t => {
 });
 
 test('skips truncated URLs', t => {
-	t.is(linkifyUrls('https://github.com/sindresorhus.com/linkify-…'), 'https://github.com/sindresorhus.com/linkify-…');
-	t.is(linkifyUrls('https://github.com/sindresorhus.com/linkify-… and https://github.com/sindresorhus.com/linkify-…'), '<a href="https://github.com/sindresorhus.com/linkify-">https://github.com/sindresorhus.com/linkify-</a>… and https://github.com/sindresorhus.com/linkify-…');
+	t.is(linkifyUrls('https://github.com/sindresorhus/linkify-…'), 'https://github.com/sindresorhus/linkify-…');
+	t.is(linkifyUrls('https://github.com/sindresorhus/linkify-… and https://github.com/sindresorhus/linkify-…'), '<a href="https://github.com/sindresorhus/linkify-">https://github.com/sindresorhus/linkify-</a>… and https://github.com/sindresorhus/linkify-…');
 	t.is(
-		html(linkifyUrls('See https://github.com/sindresorhus.com/linkify-urls… and https://github.com/sindresorhus.com/linkify-…', {
+		html(linkifyUrls('See https://github.com/sindresorhus/linkify-urls… and https://github.com/sindresorhus/linkify-…', {
 			type: 'dom',
 		})),
-		html(domify('See <a href="https://github.com/sindresorhus.com/linkify-urls">https://github.com/sindresorhus.com/linkify-urls</a>… and https://github.com/sindresorhus.com/linkify-…')),
+		html(domify('See <a href="https://github.com/sindresorhus/linkify-urls">https://github.com/sindresorhus/linkify-urls</a>… and https://github.com/sindresorhus/linkify-…')),
 	);
 	t.is(
-		html(linkifyUrls('See https://github.com/sindresorhus.com/linkify-urls and https://github.com/sindresorhus.com/linkify-…', {
+		html(linkifyUrls('See https://github.com/sindresorhus/linkify-urls and https://github.com/sindresorhus/linkify-…', {
 			type: 'dom',
 		})),
-		html(domify('See <a href="https://github.com/sindresorhus.com/linkify-urls">https://github.com/sindresorhus.com/linkify-urls</a> and https://github.com/sindresorhus.com/linkify-…')),
+		html(domify('See <a href="https://github.com/sindresorhus/linkify-urls">https://github.com/sindresorhus/linkify-urls</a> and https://github.com/sindresorhus/linkify-…')),
 	);
 });

--- a/test.js
+++ b/test.js
@@ -151,16 +151,20 @@ test('supports localhost URLs', t => {
 test('skips truncated URLs', t => {
 	t.is(linkifyUrls('https://github.com/sindresorhus/linkify-…'), 'https://github.com/sindresorhus/linkify-…');
 	t.is(linkifyUrls('https://github.com/sindresorhus/linkify-… and https://github.com/sindresorhus/linkify-…'), '<a href="https://github.com/sindresorhus/linkify-">https://github.com/sindresorhus/linkify-</a>… and https://github.com/sindresorhus/linkify-…');
-	t.is(
-		html(linkifyUrls('See https://github.com/sindresorhus/linkify-urls… and https://github.com/sindresorhus/linkify-…', {
-			type: 'dom',
-		})),
-		html(domify('See <a href="https://github.com/sindresorhus/linkify-urls">https://github.com/sindresorhus/linkify-urls</a>… and https://github.com/sindresorhus/linkify-…')),
-	);
+	t.is(linkifyUrls('https://github.com/sindresorhus/linkify-urls and more…'), '<a href="https://github.com/sindresorhus/linkify-urls">https://github.com/sindresorhus/linkify-urls</a> and more…');
+});
+
+test('skips truncated URLs (DOM)', t => {
 	t.is(
 		html(linkifyUrls('See https://github.com/sindresorhus/linkify-urls and https://github.com/sindresorhus/linkify-…', {
 			type: 'dom',
 		})),
 		html(domify('See <a href="https://github.com/sindresorhus/linkify-urls">https://github.com/sindresorhus/linkify-urls</a> and https://github.com/sindresorhus/linkify-…')),
+	);
+	t.is(
+		html(linkifyUrls('See https://github.com/sindresorhus/linkify-urls… and https://github.com/sindresorhus/linkify-…', {
+			type: 'dom',
+		})),
+		html(domify('See <a href="https://github.com/sindresorhus/linkify-urls">https://github.com/sindresorhus/linkify-urls</a>… and https://github.com/sindresorhus/linkify-…')),
 	);
 });

--- a/test.js
+++ b/test.js
@@ -150,6 +150,13 @@ test('supports localhost URLs', t => {
 
 test('skips truncated URLs', t => {
 	t.is(linkifyUrls('https://github.com/sindresorhus.com/linkify-…'), 'https://github.com/sindresorhus.com/linkify-…');
+	t.is(linkifyUrls('https://github.com/sindresorhus.com/linkify-… and https://github.com/sindresorhus.com/linkify-…'), '<a href="https://github.com/sindresorhus.com/linkify-">https://github.com/sindresorhus.com/linkify-</a>… and https://github.com/sindresorhus.com/linkify-…');
+	t.is(
+		html(linkifyUrls('See https://github.com/sindresorhus.com/linkify-urls… and https://github.com/sindresorhus.com/linkify-…', {
+			type: 'dom',
+		})),
+		html(domify('See <a href="https://github.com/sindresorhus.com/linkify-urls">https://github.com/sindresorhus.com/linkify-urls</a>… and https://github.com/sindresorhus.com/linkify-…')),
+	);
 	t.is(
 		html(linkifyUrls('See https://github.com/sindresorhus.com/linkify-urls and https://github.com/sindresorhus.com/linkify-…', {
 			type: 'dom',

--- a/test.js
+++ b/test.js
@@ -150,11 +150,11 @@ test('supports localhost URLs', t => {
 
 test('skips truncated URLs', t => {
 	t.is(linkifyUrls('https://github.com/sindresorhus/linkify-…'), 'https://github.com/sindresorhus/linkify-…');
-	t.is(linkifyUrls('https://github.com/sindresorhus/linkify-… and https://github.com/sindresorhus/linkify-…'), '<a href="https://github.com/sindresorhus/linkify-">https://github.com/sindresorhus/linkify-</a>… and https://github.com/sindresorhus/linkify-…');
+	t.is(linkifyUrls('https://github.com/sindresorhus/linkify-… and https://github.com/sindresorhus/linkify-…'), 'https://github.com/sindresorhus/linkify-… and https://github.com/sindresorhus/linkify-…');
 	t.is(linkifyUrls('https://github.com/sindresorhus/linkify-urls and more…'), '<a href="https://github.com/sindresorhus/linkify-urls">https://github.com/sindresorhus/linkify-urls</a> and more…');
 
 	t.is(linkifyUrls('https://github.com/sindresorhus/linkify-...'), 'https://github.com/sindresorhus/linkify-...');
-	t.is(linkifyUrls('https://github.com/sindresorhus/linkify-... and https://github.com/sindresorhus/linkify-...'), '<a href="https://github.com/sindresorhus/linkify-...">https://github.com/sindresorhus/linkify-...</a> and https://github.com/sindresorhus/linkify-...');
+	t.is(linkifyUrls('https://github.com/sindresorhus/linkify-... and https://github.com/sindresorhus/linkify-...'), 'https://github.com/sindresorhus/linkify-... and https://github.com/sindresorhus/linkify-...');
 	t.is(linkifyUrls('https://github.com/sindresorhus/linkify-urls and more...'), '<a href="https://github.com/sindresorhus/linkify-urls">https://github.com/sindresorhus/linkify-urls</a> and more...');
 });
 
@@ -169,7 +169,7 @@ test('skips truncated URLs (DocumentFragment)', t => {
 		html(linkifyUrls('See https://github.com/sindresorhus/linkify-urls… and https://github.com/sindresorhus/linkify-…', {
 			type: 'dom',
 		})),
-		html(domify('See <a href="https://github.com/sindresorhus/linkify-urls">https://github.com/sindresorhus/linkify-urls</a>… and https://github.com/sindresorhus/linkify-…')),
+		html(domify('See https://github.com/sindresorhus/linkify-urls… and https://github.com/sindresorhus/linkify-…')),
 	);
 
 	t.is(
@@ -179,9 +179,9 @@ test('skips truncated URLs (DocumentFragment)', t => {
 		html(domify('See <a href="https://github.com/sindresorhus/linkify-urls">https://github.com/sindresorhus/linkify-urls</a> and https://github.com/sindresorhus/linkify-...')),
 	);
 	t.is(
-		html(linkifyUrls('See https://github.com/sindresorhus/linkify-urls... and https://github.com/sindresorhus/linkify-...', {
+		html(linkifyUrls('See https://github.com/sindresorhus/linkify-... and https://github.com/sindresorhus/linkify-...', {
 			type: 'dom',
 		})),
-		html(domify('See <a href="https://github.com/sindresorhus/linkify-urls...">https://github.com/sindresorhus/linkify-urls...</a> and https://github.com/sindresorhus/linkify-...')),
+		html(domify('See https://github.com/sindresorhus/linkify-... and https://github.com/sindresorhus/linkify-...')),
 	);
 });

--- a/test.js
+++ b/test.js
@@ -152,9 +152,13 @@ test('skips truncated URLs', t => {
 	t.is(linkifyUrls('https://github.com/sindresorhus/linkify-…'), 'https://github.com/sindresorhus/linkify-…');
 	t.is(linkifyUrls('https://github.com/sindresorhus/linkify-… and https://github.com/sindresorhus/linkify-…'), '<a href="https://github.com/sindresorhus/linkify-">https://github.com/sindresorhus/linkify-</a>… and https://github.com/sindresorhus/linkify-…');
 	t.is(linkifyUrls('https://github.com/sindresorhus/linkify-urls and more…'), '<a href="https://github.com/sindresorhus/linkify-urls">https://github.com/sindresorhus/linkify-urls</a> and more…');
+
+	t.is(linkifyUrls('https://github.com/sindresorhus/linkify-...'), 'https://github.com/sindresorhus/linkify-...');
+	t.is(linkifyUrls('https://github.com/sindresorhus/linkify-... and https://github.com/sindresorhus/linkify-...'), '<a href="https://github.com/sindresorhus/linkify-...">https://github.com/sindresorhus/linkify-...</a> and https://github.com/sindresorhus/linkify-...');
+	t.is(linkifyUrls('https://github.com/sindresorhus/linkify-urls and more...'), '<a href="https://github.com/sindresorhus/linkify-urls">https://github.com/sindresorhus/linkify-urls</a> and more...');
 });
 
-test('skips truncated URLs (DOM)', t => {
+test('skips truncated URLs (DocumentFragment)', t => {
 	t.is(
 		html(linkifyUrls('See https://github.com/sindresorhus/linkify-urls and https://github.com/sindresorhus/linkify-…', {
 			type: 'dom',
@@ -166,5 +170,18 @@ test('skips truncated URLs (DOM)', t => {
 			type: 'dom',
 		})),
 		html(domify('See <a href="https://github.com/sindresorhus/linkify-urls">https://github.com/sindresorhus/linkify-urls</a>… and https://github.com/sindresorhus/linkify-…')),
+	);
+
+	t.is(
+		html(linkifyUrls('See https://github.com/sindresorhus/linkify-urls and https://github.com/sindresorhus/linkify-...', {
+			type: 'dom',
+		})),
+		html(domify('See <a href="https://github.com/sindresorhus/linkify-urls">https://github.com/sindresorhus/linkify-urls</a> and https://github.com/sindresorhus/linkify-...')),
+	);
+	t.is(
+		html(linkifyUrls('See https://github.com/sindresorhus/linkify-urls... and https://github.com/sindresorhus/linkify-...', {
+			type: 'dom',
+		})),
+		html(domify('See <a href="https://github.com/sindresorhus/linkify-urls...">https://github.com/sindresorhus/linkify-urls...</a> and https://github.com/sindresorhus/linkify-...')),
 	);
 });


### PR DESCRIPTION
Closes #39 

~`getAsString` skip linkifying if the input ends with `…` and the URL is next to that `…`.~

~`getAsDocumentFragment` skip linkifying if the URL is the second to last item and the last item is `…`.~

Skips linkifying any URL followed by `…` or `...`